### PR TITLE
Change flags and enable rpc and engine api by default

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,4 +11,22 @@ USER besu
 
 ENV BESU_OPTS=$BESU_OPTS
 
-ENTRYPOINT besu --rpc-ws-host='0.0.0.0' --rpc-ws-enabled=$WS_ENABLED --rpc-http-host='0.0.0.0' --rpc-http-enabled=$RPC_ENABLED --host-allowlist=* --rpc-http-cors-origins=* --engine-rpc-port=8551 --engine-host-allowlist=* --engine-jwt-secret='/jwtsecret' --engine-rpc-enabled=$ENGINE_API_ENABLED --data-storage-format=$STORAGE_FORMAT --metrics-enabled --metrics-host='0.0.0.0' --data-path=/var/lib/besu --sync-mode=$SYNC_MODE --rpc-http-max-active-connections=$MAX_HTTP_CONNECTIONS --p2p-port=$P2P_PORT $EXTRA_OPTS
+ENTRYPOINT besu \
+    --rpc-ws-host='0.0.0.0' \ 
+    --rpc-ws-enabled=$WS_ENABLED \
+    --rpc-http-host='0.0.0.0' \
+    --rpc-http-enabled=true \ 
+    --host-allowlist=* \
+    --rpc-http-cors-origins=* \
+    --engine-rpc-port=8551 \
+    --engine-host-allowlist=* \
+    --engine-jwt-secret='/jwtsecret' \
+    --engine-rpc-enabled=true \
+    --data-storage-format=$STORAGE_FORMAT \
+    --metrics-enabled \
+    --metrics-host='0.0.0.0' \
+    --data-path=/var/lib/besu \
+    --sync-mode=$SYNC_MODE \
+    --rpc-http-max-active-connections=$MAX_HTTP_CONNECTIONS \
+    --p2p-port=$P2P_PORT \
+    $EXTRA_OPTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,11 @@ services:
       STORAGE_FORMAT: BONSAI
       SYNC_MODE: FAST
       CONFIG_MODE: normal
-      ENGINE_API_ENABLED: "true"
       WS_ENABLED: "true"
-      RPC_ENABLED: "true"
       MAX_HTTP_CONNECTIONS: "170"
       P2P_PORT: "30414"
       BESU_OPTS: ""
-    image: "besu.dnp.dappnode.eth:1.2.1"
+    image: "node.besu.dnp.dappnode.eth:1.2.1"
     restart: unless-stopped
 volumes:
   data: {}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -64,32 +64,6 @@ fields:
       - "true"
       - "false"
     required: true
-  - title: Enable JSON-RPC API
-    id: enable_rpc
-    description: >-
-      You can enable or disable the JSON-RPC API here, if needed.
-    target:
-      type: environment
-      name: RPC_ENABLED
-      service: node
-    enum:
-      - "true"
-      - "false"
-    required: true
-  - title: Enable Engine API
-    id: enable_engine_api
-    description: >-
-      You can enable or disable the Engine API (the interface that communicates with your Consensus Layer Client) here.  
-        
-      It is not recommend that you turn this off **after the merge** if you are an active staker because you will stop attesting and proposing if the interface is down.
-    target:
-      type: environment
-      name: ENGINE_API_ENABLED
-      service: besu.public.dappnode.eth
-    enum:
-      - "true"
-      - "false"
-    required: true
   - title: Max HTTP RPC connections
     id: max_rpc_connections_http
     description: >-


### PR DESCRIPTION
This change modifies:
- RPC endpoint is enabled by default
- Engine API is enabled by default
- Make easier to read the entrypoint