### PR TITLE
fix typos and add info for new options in setup wizard

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -22,7 +22,7 @@ fields:
       You can read about the differences [here](https://besu.hyperledger.org/en/stable/Concepts/Data-Storage-Formats). 
 
 
-      Standard is BONSAI.
+      Default storage format is BONSAI.
     target:
       type: environment
       name: STORAGE_FORMAT
@@ -35,13 +35,13 @@ fields:
   - title: Sync Mode
     id: sync_mode
     description: >-
-      Besu can use one of three sync modes, FULL (slow, archive node), FAST (fast, full node) or X_SNAP (fastest, experimental and works with BONSAI). 
+      Besu can use one of three sync modes, FULL (slow, archive node), FAST (fast, full node), X_SNAP (faster, experimental and works with BONSAI), and X_CHECKPOINT (Fastest, and latest sync method works with BONSAI). 
 
 
       You can read about the differences [here](https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#sync-mode). 
 
 
-      Standard is FULL.
+      Default sync mode is FAST.
     target:
       type: environment
       name: SYNC_MODE


### PR DESCRIPTION
fixed wording
fixed text saying the wrong sync mode is default
added info about X_CHECKPOINT sync method, option was added versions ago but a description of the mode or even any mention of it aside from it being an option in the ENUM was missing.