### PR TITLE
Switch default sync mode from FAST

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       EXTRA_OPTS: ""
       STORAGE_FORMAT: BONSAI
-      SYNC_MODE: FAST
+      SYNC_MODE: X_CHECKPOINT
       CONFIG_MODE: normal
       WS_ENABLED: "true"
       MAX_HTTP_CONNECTIONS: "170"


### PR DESCRIPTION
FAST sync is no longer the preferred method. We have only kept the X mark for other sync modes in order to force ourselves to implement snap sync as a server.