### PR TITLE
update wizard for new flags

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -35,22 +35,22 @@ fields:
   - title: Sync Mode
     id: sync_mode
     description: >-
-      Besu can use one of three sync modes, FULL (slow, archive node), FAST (fast, full node), X_SNAP (faster, experimental and works with BONSAI), and X_CHECKPOINT (Fastest, and latest sync method works with BONSAI). 
+      Besu can use one of three sync modes, FULL (slow, archive node), FAST (fast, full node), SNAP (faster and works with BONSAI), and CHECKPOINT (Fastest, and smallest on disk works with BONSAI. Cannot serve full chain history to peers). 
 
 
       You can read about the differences [here](https://besu.hyperledger.org/stable/public-networks/get-started/connect/sync-node). 
 
 
-      Default sync mode is X_CHECKPOINT.
+      Default sync mode is CHECKPOINT.
     target:
       type: environment
       name: SYNC_MODE
       service: besu
     enum:
-      - X_CHECKPOINT
+      - CHECKPOINT
       - FAST
       - FULL
-      - X_SNAP
+      - SNAP
     required: true
     if: { "config_mode": { "enum": ["advanced"] } }
   - title: Enable WebSocket API


### PR DESCRIPTION
We have deprecated the X experimental flags for SNAP and CHECKPOINT. This PR reflects those changes. 